### PR TITLE
Allow nested scrolled element

### DIFF
--- a/static/gallery/js/image_upload.js
+++ b/static/gallery/js/image_upload.js
@@ -1,8 +1,9 @@
 /**
 Provide drag and drop support on image display pages
 */
-
 document.addEventListener('drop', function(event) {
+    event.stopPropagation();
+    event.preventDefault();
     var drop_container = document.getElementById('image_container');
     var image_form = document.getElementById('image_upload_form');
     var data_input  = image_form.elements['data'];
@@ -12,16 +13,17 @@ document.addEventListener('drop', function(event) {
     data_input.files = event.dataTransfer.files;
     image_form.submit();
 
-    event.preventDefault();
 });
 
 document.addEventListener('dragover', function(event) {
+    event.stopPropagation();
     event.preventDefault();
 });
 
 document.addEventListener('dragenter', function(event) {
     var drop_container = document.getElementById('image_container');
     drop_container.classList.add('highlight');
+    event.stopPropagation();
     event.preventDefault();
 });
 

--- a/static/gallery/js/infinite_scroll.js
+++ b/static/gallery/js/infinite_scroll.js
@@ -4,17 +4,18 @@ var pagination_size = 40;
 var scroll_cursor = 0;
 
 function init_infinite_scroll() {
-        load_images_from_cursor(scroll_cursor);
+    load_images_from_cursor(scroll_cursor);
 }
 
-function check_infinite_scroll() {
-
+function check_infinite_scroll(event) {
     // Based on https://benjaminhorn.io/code/how-to-implement-infinite-scroll/
+    // Modified to handle a scrollable element nested within fixed elements by
+    // referring to event.target
     // Fetch variables
-    var scrollTop = window.scrollY;
-    var windowHeight = window.innerHeight;
-    var bodyHeight = document.body.scrollHeight - windowHeight;
-    var scrollPercentage = (scrollTop / bodyHeight);
+    let scrollTop = event.target.scrollTop;
+    let windowHeight = event.target.clientHeight;
+    let bodyHeight = event.target.scrollHeight - windowHeight;
+    let scrollPercentage = (scrollTop / bodyHeight);
 
     // if the scroll is more than 90% from the top, load more content.
     if (scrollPercentage > 0.7) {
@@ -38,6 +39,7 @@ function load_images_from_cursor(cursor) {
 
         if (i >= images.length) {
             // All images have been set to load
+            scroll_cursor += i; // Set scroll cursor for further image loads
             window.removeEventListener('scroll',check_infinite_scroll);
             return;
         }
@@ -55,4 +57,4 @@ function load_images_from_cursor(cursor) {
 }
 
 window.addEventListener('load',init_infinite_scroll);
-window.addEventListener('scroll',check_infinite_scroll);
+window.addEventListener('scroll',check_infinite_scroll,{ capture: true });

--- a/static/gallery/js/infinite_scroll.js
+++ b/static/gallery/js/infinite_scroll.js
@@ -39,7 +39,6 @@ function load_images_from_cursor(cursor) {
 
         if (i >= images.length) {
             // All images have been set to load
-            scroll_cursor += i; // Set scroll cursor for further image loads
             window.removeEventListener('scroll',check_infinite_scroll);
             return;
         }
@@ -57,4 +56,4 @@ function load_images_from_cursor(cursor) {
 }
 
 window.addEventListener('load',init_infinite_scroll);
-window.addEventListener('scroll',check_infinite_scroll,{ capture: true });
+window.addEventListener('scroll',check_infinite_scroll);

--- a/static/gallery/js/justify_images.js
+++ b/static/gallery/js/justify_images.js
@@ -9,7 +9,7 @@
 
 
 
-function justify_images() {
+function justify_images(event) {
 /** Fix the width each image in a container to fully justify each row */
 
     var container = document.getElementById('image_container');
@@ -33,6 +33,7 @@ function justify_images() {
         row_width += (images[i].naturalWidth / hdpi_factor);
         // Look ahead to see how wide the next image is
         var next_half_width = 0;
+        var resize_factor = 1;  // Initialize for orphans too...
         if (i < images.length - 1) {
             next_half_width = images[i+1].naturalWidth / hdpi_factor / 2 ;
         }
@@ -42,7 +43,7 @@ function justify_images() {
             // Account for the total width of all margins on this row
             var margin_total = image_margin * (row_images.length - 1);
             // Find the factor required to shrink or enlarge the images in this row
-            var resize_factor = (container_width - margin_total) / (row_width - margin_total);
+            resize_factor = (container_width - margin_total) / (row_width - margin_total);
             resize_row(row_images, resize_factor);
             // Reset values for new row
             row_width = 0;
@@ -67,9 +68,10 @@ function resize_row(images, factor) {
 
         var overlay = images[i].nextElementSibling;
         var width = ((images[i].naturalWidth / hdpi_factor) * factor);
-        images[i].style.width = width + "px";
+        // html spec says these must be integers without a unit...
+        images[i].width = Math.floor(width);
         var height = ((images[i].naturalHeight / hdpi_factor) * factor);
-        images[i].style.height = height + "px";
+        images[i].height = Math.floor(height);
         // Add a margin to image and overlay if this is not the last image
         if (i < (images.length - 1)) {
             images[i].classList.add('image_spacer');

--- a/static/gallery/js/justify_images.js
+++ b/static/gallery/js/justify_images.js
@@ -68,10 +68,9 @@ function resize_row(images, factor) {
 
         var overlay = images[i].nextElementSibling;
         var width = ((images[i].naturalWidth / hdpi_factor) * factor);
-        // html spec says these must be integers without a unit...
-        images[i].width = Math.floor(width);
+        images[i].style.width = width + "px";
         var height = ((images[i].naturalHeight / hdpi_factor) * factor);
-        images[i].height = Math.floor(height);
+        images[i].style.height = height + "px";
         // Add a margin to image and overlay if this is not the last image
         if (i < (images.length - 1)) {
             images[i].classList.add('image_spacer');


### PR DESCRIPTION
Hi,
Here are a few essential fixes to the javascript code that I ran across when working on my site with over 100 albums and 6000+ images.  The bugs were manifesting themselves as flickers on scroll and misaligned wide (panorama) images.  The diffs and inspection will reveal the problems in the code.

One small 'feature improvement' in `infinite_scroll.js`, that should be backward compatible, is to allow the scrolled (overflow) element to be nested inside the document and reached through `event.target`, something I needed due to the layout of our site.

(Should you care to see its operation, its our now 16-year old sailboatdazzle.com site (started under django 0.x) and presently under django 4.x and python 3.10...  Some time ago I was compelled to add an email-based registration start page with a simple captcha, no passwords required or generated, returns a link via email and remembers the session per device).

I hope this helps improve your app should you choose to pull this in.  Please let me know if...  I have further improvements in the python code, those I will have to put into another branch of my fork for review.

Thanks for the great app!  Best regards, Zoltan