### PR TITLE
Support S3 object storage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,9 @@ The actual preview and thumbnail sizes are multiplied by this number, but render
 
 Margin between thumbnails in px. This can create a more or less condensed look
 
+**GALLERY_STORAGE** -- Default: "django.core.files.storage.FileSystemStorage"
+
+Storage class definition for the images. Can be used to configure S3
 
 Troubleshooting
 ---------------

--- a/admin.py
+++ b/admin.py
@@ -17,6 +17,7 @@ class ImageAdmin(admin.ModelAdmin):
     list_filter = ('image_albums',)
     list_per_page = 25
     readonly_fields = ('admin_thumbnail',)
+    exclude = ('exif_json',)
 
 
 class AlbumAdmin(SortableAdminMixin, admin.ModelAdmin):

--- a/settings.py
+++ b/settings.py
@@ -24,3 +24,5 @@ GALLERY_HDPI_FACTOR = getattr(settings, 'GALLERY_HDPI_FACTOR', 2)
 GALLERY_IMAGE_MARGIN = getattr(settings, 'GALLERY_IMAGE_MARGIN', 6.0)
 # CSS Color Styling
 GALLERY_THEME_COLOR = getattr(settings, 'GALLERY_THEME_COLOR', "black")
+# Gallery Storage
+GALLERY_STORAGE = getattr(settings, 'GALLERY_STORAGE', "django.core.files.storage.FileSystemStorage")

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = ['django-imagekit', 'Pillow']
 
 setup(
     name='django-starcross-gallery',
-    version='1.1',
+    version='1.1.0.1',
     packages=find_packages(),
     include_package_data=True,
     license='GNU LGPLv3',

--- a/templates/gallery/album_detail.html
+++ b/templates/gallery/album_detail.html
@@ -35,7 +35,7 @@
     {% endfor %}
 
 
-    {% if not album.images.all and user.is_authenticated %}
+    {% if not album.images.all and perms.gallery.add_image and perms.gallery.change_album %}
 
         <div id="empty_placeholder">
             Drag images into this box to upload to the album

--- a/templates/gallery/image_list.html
+++ b/templates/gallery/image_list.html
@@ -34,7 +34,7 @@
     {% endfor %}
 
 
-    {% if not image_list and user.is_authenticated %}
+    {% if not image_list and perms.gallery.add_image and perms.gallery.change_album %}
 
         <div id="empty_placeholder">
             Drag images into this box to upload to the image feed

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -124,3 +124,6 @@ class ImageTests(TestCase):
         data = {'data': SimpleUploadedFile('text.txt', b'text')}
         response = self.client.post(reverse('gallery:image_upload'), data=data)
         self.assertContains(response, "Unable to add invalid image", msg_prefix="Error testing invalid image data")
+
+    def test_image_modified_time(self):
+        self.assertIsInstance(self.image.mtime, datetime)


### PR DESCRIPTION
Really like this gallery, simple to set up and simple to use.
It only lacks a couple of aspects that I need, so I'm happy to contribute. This pull request adds support for S3 storage when the files are stored externally. Default is local file storage, so its behaviour will not change with this update.