### PR TITLE
Merged - Changes Helpful for Integration of Starcross Gallery into another site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /django-starcross-gallery/
+/tests/media/

--- a/admin.py
+++ b/admin.py
@@ -20,11 +20,13 @@ class ImageAdmin(admin.ModelAdmin):
 
 
 class AlbumAdmin(SortableAdminMixin, admin.ModelAdmin):
-    list_display = ('order', 'title')
+    ordering = ['-order']
+    
+    list_display = ('title', 'published', 'order', 'order_number')
     list_display_links = ('title',)
     if hasattr(SortableAdminMixin, 'mock'):
         list_editable = ('order',)
-        list_display = ('title', 'order')
+        list_display = ('title', 'published', 'order')
     filter_horizontal = ('images',)
     raw_id_fields = ('highlight',)
 

--- a/admin.py
+++ b/admin.py
@@ -12,15 +12,24 @@ else:
 
 
 class ImageAdmin(admin.ModelAdmin):
+    ordering = ['-date_taken']
+
     admin_thumbnail = AdminThumbnail(image_field='data_thumbnail', template='gallery/admin/thumbnail.html')
-    list_display = ('title', 'admin_thumbnail', 'date_taken', 'date_uploaded')
+    list_display = ('title', 'admin_thumbnail', 'size_str', 'date_taken', 'date_uploaded')
     list_filter = ('image_albums',)
     list_per_page = 25
-    readonly_fields = ('admin_thumbnail',)
+    readonly_fields = ('admin_thumbnail', 'size_str')
+    search_fields = ('data',)
+    
+    def delete_queryset(self, request, queryset):
+        for img in queryset:
+            self.delete_model(request, img)
+
 
 
 class AlbumAdmin(SortableAdminMixin, admin.ModelAdmin):
-    list_display = ('order', 'title')
+    ordering = ['-order']
+    list_display = ('order', 'title', 'order_number')
     list_display_links = ('title',)
     if hasattr(SortableAdminMixin, 'mock'):
         list_editable = ('order',)
@@ -28,8 +37,9 @@ class AlbumAdmin(SortableAdminMixin, admin.ModelAdmin):
     filter_horizontal = ('images',)
     raw_id_fields = ('highlight',)
 
+    @admin.display(description='order#')
+    def order_number(self, album):
+        return album.order
 
 admin.site.register(Image, ImageAdmin)
 admin.site.register(Album, AlbumAdmin)
-
-

--- a/admin.py
+++ b/admin.py
@@ -30,6 +30,9 @@ class AlbumAdmin(SortableAdminMixin, admin.ModelAdmin):
     filter_horizontal = ('images',)
     raw_id_fields = ('highlight',)
 
+    @admin.display(description='order#')
+    def order_number(self, album):
+        return album.order
 
 admin.site.register(Image, ImageAdmin)
 admin.site.register(Album, AlbumAdmin)

--- a/models.py
+++ b/models.py
@@ -64,7 +64,7 @@ class Image(models.Model):
     def size_str(self):
         if not hasattr(self, 'width'):
             try:
-                with pImage.open(self.source.path) as img:
+                with pImage.open(self.data.path) as img:
                     self.width = img.width
                     self.height = img.height
                     img.close()

--- a/models.py
+++ b/models.py
@@ -20,7 +20,7 @@ class Image(models.Model):
         source='data',
         processors=[ResizeToFit(height=settings.GALLERY_THUMBNAIL_SIZE * settings.GALLERY_HDPI_FACTOR)],
         format='JPEG',
-        options={'quality': settings.GALLERY_RESIZE_QUALITY, 'keep_exif':True}
+        options={'quality': settings.GALLERY_RESIZE_QUALITY}
     )
     data_preview = ImageSpecField(
         source='data',

--- a/models.py
+++ b/models.py
@@ -109,9 +109,10 @@ class Album(models.Model):
         on_delete=models.SET_NULL,
     )
     order = models.PositiveIntegerField(default=0, blank=False, null=False)
-
+    published = models.BooleanField(default=True)
+    
     class Meta(object):
-        ordering = ['order', '-pk']
+        ordering = ['-order', '-pk']
 
     @property
     def slug(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-requirements = ['django-imagekit', 'Pillow']
+requirements = ['django-imagekit', 'Pillow', 'piexif']
 
 setup(
     name='django-starcross-gallery',

--- a/static/gallery/js/infinite_scroll.js
+++ b/static/gallery/js/infinite_scroll.js
@@ -4,7 +4,7 @@ const pagination_size = 40;
 let scroll_cursor = 0;
 
 function init_infinite_scroll() {
-    load_images_from_cursor(scroll_cursor);
+    scroll_cursor = load_images_from_cursor(scroll_cursor);
 }
 
 function check_infinite_scroll(event) {
@@ -20,20 +20,20 @@ function check_infinite_scroll(event) {
 
     // if the scroll is more than 90% from the top, load more content.
     if (scrollPercentage > 0.7) {
-        load_images_from_cursor(scroll_cursor);
+        scroll_cursor = load_images_from_cursor(scroll_cursor);
     }
 
 }
 
-function load_images_from_cursor() {
+function load_images_from_cursor(cursor) {
     // Find the images in the thumbnail container
     const images = document.querySelectorAll('.image');
     const thumbnails = document.querySelectorAll('.thumbnail');
 
-    let i = scroll_cursor; // start from last position
+    let i = cursor; // start from last position
     
     // Change the source of the next page of images if any left
-    for (; i < images.length && i < scroll_cursor + pagination_size; i++) {
+    for (; i < images.length && i < cursor + pagination_size; i++) {
         // Re-justify after this image has loaded
         images[i].addEventListener('load', justify_images);
         // and change its display property to show it
@@ -42,11 +42,11 @@ function load_images_from_cursor() {
         const src = images[i].getAttribute('data-src');
         images[i].setAttribute('src', src);
     }
-    if (i >= images.length && scroll_cursor < images.length) {
+    if (i >= images.length && cursor < images.length) {
         // All images have been set to load, no further need
         window.removeEventListener('scroll',check_infinite_scroll);
     }
-    scroll_cursor = i;  // remember last position
+    return i;
 }
 
 window.addEventListener('load',init_infinite_scroll);

--- a/templates/gallery/album_list.html
+++ b/templates/gallery/album_list.html
@@ -1,3 +1,4 @@
+{# -*- mode:web -*- engine:django -*- #}
 {% extends "gallery/gallery_base.html" %}
 {% load static %}
 
@@ -20,19 +21,9 @@
 
 <div id="image_container">
 
-{% for album in object_list %}
-    <a href="{% url 'gallery:album_detail' album.pk album.slug  %}">
-    
-            {% with image=album.display_highlight %}
-                {% if image %}
-                    {% include "gallery/partials/thumbnail.html" %}
-                {% else %}
-                    {% include "gallery/partials/thumbnail_empty.html" %}
-                {% endif %}
-            {% endwith %}
-        
-    </a>
-{% endfor %}
+  {% for album in object_list %}
+    {% include "gallery/partials/album.html" %}  
+  {% endfor %}
 
 </div>
 

--- a/templates/gallery/partials/album.html
+++ b/templates/gallery/partials/album.html
@@ -1,0 +1,12 @@
+{# -*- mode:web -*- engine:django -*- #}
+<a href="{% url 'gallery:album_detail' album.pk album.slug  %}">
+  
+  {% with image=album.display_highlight %}
+    {% if image %}
+      {% include "gallery/partials/thumbnail.html" %}
+    {% else %}
+      {% include "gallery/partials/thumbnail_empty.html" %}
+    {% endif %}
+  {% endwith %}
+  
+</a>

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -43,3 +43,5 @@ TEMPLATES = [
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 STATIC_URL = '/static/'
+
+USE_TZ = False

--- a/views.py
+++ b/views.py
@@ -120,6 +120,3 @@ class AlbumList(GallerySettingsMixin, ListView):
         else:
             return Album.objects.exclude(published=False)
 
-
-class ImageFullView(ImageView):
-    template_name = 'gallery/image_full.html'

--- a/views.py
+++ b/views.py
@@ -51,7 +51,7 @@ class ImageView(GallerySettingsMixin, DetailView):
                         context['next_image'] = album_images[i + 1]
         else:
             # Look for albums this image appears in
-            context['albums'] = self.object.image_albums.all()
+            context['albums'] = self.object.image_albums.exclude(published=False)
 
         return context
 
@@ -114,3 +114,12 @@ class AlbumView(GallerySettingsMixin, DetailView):
 class AlbumList(GallerySettingsMixin, ListView):
     model = Album
     template_name = 'gallery/album_list.html'
+    def get_queryset(self):
+        if self.request.user and self.request.user.is_staff:
+            return Album.objects.all()
+        else:
+            return Album.objects.exclude(published=False)
+
+
+class ImageFullView(ImageView):
+    template_name = 'gallery/image_full.html'


### PR DESCRIPTION
Hi Alex, here are the pared-down merged list of changes in my fork for integration into sailboatdazzle.com.  Long delayed, because I had to find the time and focus to disentangle and undo some of many cosmetic changes and additional changes in Image/Album management, but now these changes in 'merged' are minimal relative to your most recent master baseline. The changes are grouped into four independent branches in my fork included in this 'merged' branch:

1.  Image.date_taken DateTimeField that is initialized from exif DateTimeOriginal if available, else the upload time.  This allows django queries to select subsets of images. Added the import of 'piexif' that I found convenient for exif info access. A computed 'size_str' Image admin display column is also added for the usual width x height info.
2. Album.published. BooleanField that is set by admin after all the images have been uploaded and arranged/assigned to an Album.  It can also serve for admin-private Albums used in support of some individual site pages
3. template_refactoring: Created templates/partials/album.html  to allow its inclusion/reuse in more than one template location
4. js_clean: This is cosmetic but aids comprehension as it emphasizes that cursor is an argument and local within load_images_from_cursor(cursor) and a return value for the 'global' scroll_cursor.

Take a look when you can and let me know any questions/comments.  We can then see if you're interested in a few more 'improvements' like cleaning the cache as well on image deletion, etc.  Best regards!